### PR TITLE
chore(dependencies): upgrade vulnerable packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <java.version>1.7</java.version>
-        <jackson.version>2.6.0</jackson.version>
+        <jackson.version>2.9.0</jackson.version>
         <joda-time.version>2.5</joda-time.version>
         <commons.lang3.version>3.3.2</commons.lang3.version>
         <commons.io.version>1.3.2</commons.io.version>
@@ -233,7 +233,7 @@
         <dependency>
             <groupId>org.restlet.jse</groupId>
             <artifactId>org.restlet</artifactId>
-            <version>2.3.9</version>
+            <version>2.3.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
There are some warnings in github vulnerability popups. This is the easy fix.