### PR TITLE
chore(update): update jackson to 2.9.9 to avoid security issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <java.version>1.7</java.version>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.9.9</jackson.version>
         <joda-time.version>2.5</joda-time.version>
         <commons.lang3.version>3.3.2</commons.lang3.version>
         <commons.io.version>1.3.2</commons.io.version>


### PR DESCRIPTION
See https://nvd.nist.gov/vuln/detail/CVE-2019-12086