### PR TITLE
 fix(backoff): the error is not necessary a HttpServerError 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
 
         <java.version>1.7</java.version>
         <jackson.version>2.9.9</jackson.version>
+        <jackson-databind.version>2.9.9.1</jackson-databind.version>
         <joda-time.version>2.5</joda-time.version>
         <commons.lang3.version>3.3.2</commons.lang3.version>
         <commons.io.version>1.3.2</commons.io.version>
@@ -85,7 +86,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson-databind.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>

--- a/src/main/java/com/mnubo/java/sdk/client/services/SDKService.java
+++ b/src/main/java/com/mnubo/java/sdk/client/services/SDKService.java
@@ -229,9 +229,15 @@ class SDKService {
                 @Override
                 public boolean canRetry(RetryContext context) {
                     Throwable t = context.getLastThrowable();
-                    HttpServerErrorException serverError = (HttpServerErrorException) t;
-                    return t == null || (serverError.getStatusCode() == HttpStatus.SERVICE_UNAVAILABLE &&
-                            context.getRetryCount() < this.getMaxAttempts());
+                    if (t == null && context.getRetryCount() <= 0) {
+                        return true;
+                    } else if (t instanceof HttpServerErrorException) {
+                        HttpServerErrorException serverError = (HttpServerErrorException) t;
+                        return (serverError.getStatusCode() == HttpStatus.SERVICE_UNAVAILABLE &&
+                                context.getRetryCount() < this.getMaxAttempts());
+                    } else {
+                        return false;
+                    }
                 }
             };
 


### PR DESCRIPTION
Not all `Throwable` found in the retry context will be `HttpServerErrorException`. Make sure it is before casting.